### PR TITLE
adding tags and exim can be removed now

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ postfix_apt_pkgs:
 postfix_pkg_state: installed
 postfix_service_state: started
 postfix_service_enabled: yes
+
+postfix_remove_exim: false
+
 postfix_main_config:
   smtpd_banner: $myhostname ESMTP $mail_name (Ubuntu)
   biff: 'no'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 
 - include: package.yml
-  tags: package
+  tags: [postfix, package]
 
 - include: configuration.yml
-  tags: configuration
+  tags: [postfix, configuration]
 
 - name: start/stop postfix service
   service:
     name: postfix
     state: '{{ postfix_service_state }}'
     enabled: '{{ postfix_service_enabled }}'
-  tags: service
+  tags: [postfix, service]

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Remove exim package
+  apt:
+    name: "{{item}}"
+    state: absent
+    purge: yes
+    force: yes
+  with_items:
+    - exim4
+    - exim4-base
+    - exim4-config
+    - exim4-daemon-light
+  when: postfix_remove_exim
+
 - name: Install specific postfix packages
   apt:
     pkg: '{{ item.name }}={{ item.version }}'


### PR DESCRIPTION
Hi,

On a Debian server, exim is the default installed mail server. So when you run the postfix role, it will install postfix as well but the port isn't be able to bind to the default one as it's already used by exim.

In addition, in most of case you don't run 2 different mails server on the same machine. That's why I suggest (but do not force) to add the possibility to remove exim directly from the role.

To finish, I've added new tags to be able to be able to select the entire role in addition of some parts.

Hope you'll merge it.

Thanks
